### PR TITLE
Feature/support bookmark properties and time extracted

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(name='tap-braintree',
       classifiers=['Programming Language :: Python :: 3 :: Only'],
       py_modules=['tap_braintree'],
       install_requires=[
-          'singer-python==1.2.0',
+          'singer-python==5.0.4',
           'requests==2.12.4',
           'braintree==3.34.0',
       ],

--- a/tap_braintree/transform.py
+++ b/tap_braintree/transform.py
@@ -1,4 +1,5 @@
 import datetime
+import pytz
 from . import utils
 
 
@@ -71,8 +72,12 @@ def _transform_field(value, field_schema):
     if field_schema["type"] == "object":
         return _object(value, field_schema["properties"])
 
-    if isinstance(value, (datetime.date, datetime.datetime)):
-        value = utils.strftime(value)
+    if isinstance(value, datetime.date):
+        dt = datetime.datetime(value.year, value.month, value.day, tzinfo=pytz.UTC)
+        value = utils.strftime(dt)
+
+    if isinstance(value, datetime.datetime):
+        value = utils.strftime(value.replace(tzinfo=pytz.UTC))
 
     value = _type_transform(value, field_schema["type"])
 


### PR DESCRIPTION
singer-python version 5.0.0 introduced `time_extracted` for the `RecordMessage` and `bookmark_properties` for the `SchemaMessage`. We are now going to support these in tap-braintree.