### PR TITLE
Disbursement date replication and daily iteration.

### DIFF
--- a/tap_braintree/__init__.py
+++ b/tap_braintree/__init__.py
@@ -132,12 +132,16 @@ def sync_transactions():
             # if disbursement is successful, get disbursement date
             # set disbursement datetime to min if not found
 
-            if row.disbursement_details.disbursement_date is None:
-                row.disbursement_details.disbursement_date = datetime.min
+            if row.disbursement_details is None:
+                disbursement_date = datetime.min
 
-            disbursement_date = to_utc(datetime.combine(
-                row.disbursement_details.disbursement_date,
-                datetime.min.time()))
+            else:
+                if row.disbursement_details.disbursement_date is None:
+                    row.disbursement_details.disbursement_date = datetime.min
+
+                disbursement_date = to_utc(datetime.combine(
+                    row.disbursement_details.disbursement_date,
+                    datetime.min.time()))
 
             # Is this more recent than our past stored value of update_at?
             # Is this more recent than our past stored value of disbursement_date?

--- a/tap_braintree/__init__.py
+++ b/tap_braintree/__init__.py
@@ -56,52 +56,125 @@ def daterange(start_date, end_date):
 
 def sync_transactions():
     schema = load_schema("transactions")
-    singer.write_schema("transactions", schema, ["id"], bookmark_properties=['created_at'])
 
-    latest_updated_at = to_utc(utils.strptime(STATE.get('latest_updated_at', DEFAULT_TIMESTAMP)))
+    singer.write_schema("transactions", schema, ["id"],
+                        bookmark_properties=['created_at'])
+
+    latest_updated_at = to_utc(utils.strptime(
+        STATE.get('latest_updated_at', DEFAULT_TIMESTAMP)))
+
     run_maximum_updated_at = latest_updated_at
+
+    latest_disbursement_date = to_utc(utils.strptime(
+        STATE.get('latest_disbursement_date', DEFAULT_TIMESTAMP)))
+
+    run_maximum_disbursement_date = latest_disbursement_date
+
     latest_start_date = to_utc(utils.strptime(get_start("transactions")))
-    start = latest_start_date - TRAILING_DAYS
-    end = utils.now()
 
-    logger.info("transactions: Syncing from {}".format(start))
-    logger.info("transactions: latest_updated_at from {}".format(latest_updated_at))
-    logger.info("transactions: latest_start_date from {}".format(latest_start_date))
+    period_start = latest_start_date - TRAILING_DAYS
 
-    data = braintree.Transaction.search(braintree.TransactionSearch.created_at.between(start, end))
-    time_extracted = utils.now()
+    period_end = utils.now()
 
-    logger.info("transactions: Fetched {} records from {} - {}".format(data.maximum_size, start, end))
+    logger.info("transactions: Syncing from {}".format(period_start))
 
-    row_written_count = 0
-    row_skipped_count = 0
+    logger.info("transactions: latest_updated_at from {}, disbursement_date from {}".format(
+        latest_updated_at, latest_disbursement_date
+    ))
 
-    for row in data:
-        # Ensure updated_at consistency
-        if not getattr(row, 'updated_at'):
-            row.updated_at = row.created_at
+    logger.info("transactions: latest_start_date from {}".format(
+        latest_start_date
+    ))
 
-        transformed = transform_row(row, schema)
-        updated_at = to_utc(row.updated_at)
+    # increment through each day (20k results max from api)
+    for start, end in daterange(period_start, period_end):
 
-        # Use >= due to non monotonic updated_at values
-        # Is this more recent than our past stored value of update_at?
-        # Update our high water mark for updated_at in this run
-        if updated_at >= latest_updated_at:
-            if updated_at > run_maximum_updated_at:
-                run_maximum_updated_at = updated_at
+        end = min(end, period_end)
 
-            singer.write_record("transactions", transformed, time_extracted=time_extracted)
-            row_written_count += 1
-        else:
-            row_skipped_count += 1
+        data = braintree.Transaction.search(
+            braintree.TransactionSearch.created_at.between(start, end))
+        time_extracted = utils.now()
 
-    logger.info("transactions: Written {} records from {} - {}".format(row_written_count, start, end))
-    logger.info("transactions: Skipped {} records from {} - {}".format(row_skipped_count, start, end))
+        logger.info("transactions: Fetched {} records from {} - {}".format(
+            data.maximum_size, start, end
+        ))
+
+        row_written_count = 0
+        row_skipped_count = 0
+
+        for row in data:
+            # Ensure updated_at consistency
+            if not getattr(row, 'updated_at'):
+                row.updated_at = row.created_at
+
+            transformed = transform_row(row, schema)
+            updated_at = to_utc(row.updated_at)
+
+            # if disbursement is successful, get disbursement date
+            # set disbursement datetime to min if not found
+
+            if row.disbursement_details.disbursement_date is None:
+                row.disbursement_details.disbursement_date = datetime.min
+
+            disbursement_date = to_utc(datetime.combine(
+                row.disbursement_details.disbursement_date,
+                datetime.min.time()))
+
+            # Is this more recent than our past stored value of update_at?
+            # Is this more recent than our past stored value of disbursement_date?
+            # Use >= for updated_at due to non monotonic updated_at values
+            # Use > for disbursement_date - confirming all transactions disbursed
+            # at the same time
+            # Update our high water mark for updated_at and disbursement_date
+            # in this run
+            if (
+                updated_at >= latest_updated_at
+            ) or (
+                disbursement_date > latest_disbursement_date
+            ):
+
+                if updated_at > run_maximum_updated_at:
+                    run_maximum_updated_at = updated_at
+
+                if disbursement_date > run_maximum_disbursement_date:
+                    run_maximum_disbursement_date = disbursement_date
+
+                singer.write_record("transactions", transformed,
+                                    time_extracted=time_extracted)
+                row_written_count += 1
+
+            else:
+
+                row_skipped_count += 1
+
+        logger.info("transactions: Written {} records from {} - {}".format(
+            row_written_count, start, end
+        ))
+
+        logger.info("transactions: Skipped {} records from {} - {}".format(
+            row_skipped_count, start, end
+        ))
+
+    # End day loop
+    logger.info("transactions: Complete. Last updated record: {}".format(
+        run_maximum_updated_at
+    ))
+
+    logger.info("transactions: Complete. Last disbursement date: {}".format(
+        run_maximum_disbursement_date
+    ))
 
     latest_updated_at = run_maximum_updated_at
+
+    latest_disbursement_date = run_maximum_disbursement_date
+
     STATE['latest_updated_at'] = utils.strftime(latest_updated_at)
+
+    STATE['latest_disbursement_date'] = utils.strftime(
+        latest_disbursement_date)
+
     utils.update_state(STATE, "transactions", utils.strftime(end))
+
     singer.write_state(STATE)
 
 

--- a/tap_braintree/__init__.py
+++ b/tap_braintree/__init__.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python3
 
-import datetime
+from datetime import datetime, timedelta
 import os
 import pytz
+
 
 import braintree
 import singer
@@ -18,6 +19,7 @@ DEFAULT_TIMESTAMP = "1970-01-01T00:00:00Z"
 
 logger = singer.get_logger()
 
+
 def get_abs_path(path):
     return os.path.join(os.path.dirname(os.path.realpath(__file__)), path)
 
@@ -31,6 +33,7 @@ def get_start(entity):
         STATE[entity] = CONFIG["start_date"]
 
     return STATE[entity]
+
 
 def to_utc(dt):
     return dt.replace(tzinfo=pytz.UTC)
@@ -93,10 +96,17 @@ def do_sync():
 
 
 def main_impl():
-    args = utils.parse_args(["merchant_id", "public_key", "private_key", "start_date"])
+    args = utils.parse_args(
+        ["merchant_id", "public_key", "private_key", "start_date"]
+    )
     config = args.config
-    environment = getattr(braintree.Environment, config.pop("environment", "Production"))
+
+    environment = getattr(
+        braintree.Environment, config.pop("environment", "Production")
+    )
+
     CONFIG['start_date'] = config.pop('start_date')
+
     braintree.Configuration.configure(environment, **config)
 
     if args.state:
@@ -104,12 +114,14 @@ def main_impl():
 
     do_sync()
 
+
 def main():
     try:
         main_impl()
     except Exception as exc:
         logger.critical(exc)
         raise exc
+
 
 if __name__ == '__main__':
     main()

--- a/tap_braintree/__init__.py
+++ b/tap_braintree/__init__.py
@@ -40,6 +40,25 @@ def to_utc(dt):
 
 
 def daterange(start_date, end_date):
+    """
+    Generator function that produces an iterable list of days between the two
+    dates start_date and end_date as a tuple pair of datetimes.
+
+    Note:
+        All times are set to 0:00. Designed to be used in date query where query
+        logic would be record_date >= 2019-01-01 0:00 and record_date < 2019-01-02 0:00
+
+    Args:
+        start_date (datetime): start of period
+        end_date (datetime): end of period
+
+    Yields:
+        tuple: daily period
+            * datetime: day within range
+            * datetime: day within range + 1 day
+
+    """
+
     # set to start of day
     start_date = to_utc(
         datetime.combine(

--- a/tap_braintree/__init__.py
+++ b/tap_braintree/__init__.py
@@ -14,7 +14,7 @@ from .transform import transform_row
 
 CONFIG = {}
 STATE = {}
-TRAILING_DAYS = datetime.timedelta(days=30)
+TRAILING_DAYS = timedelta(days=30)
 DEFAULT_TIMESTAMP = "1970-01-01T00:00:00Z"
 
 logger = singer.get_logger()
@@ -37,6 +37,22 @@ def get_start(entity):
 
 def to_utc(dt):
     return dt.replace(tzinfo=pytz.UTC)
+
+
+def daterange(start_date, end_date):
+    # set to start of day
+    start_date = to_utc(
+        datetime.combine(
+            start_date.date(),
+            datetime.min.time()  # set to the 0:00 on the day of the start date
+        )
+    )
+
+    end_date = to_utc(end_date + timedelta(1))
+
+    for n in range(int((end_date - start_date).days)):
+        yield start_date + timedelta(n), start_date + timedelta(n + 1)
+
 
 def sync_transactions():
     schema = load_schema("transactions")

--- a/tests/test_tap_braintree.py
+++ b/tests/test_tap_braintree.py
@@ -1,0 +1,67 @@
+import unittest
+import tap_braintree
+import pytz
+
+from datetime import datetime, timedelta
+
+
+class TestDateRangeUtility(unittest.TestCase):
+
+    def test_daterange_normal(self):
+        """
+        When given two dates 7 days apart, function should return
+        generator that iterates 8 sets of tuples where the second
+        value equals the next day's first.
+
+        The last iteration should be the same as 
+        (end_date, end_date + timedelta(1)), where the time portion
+        of the date has been set to 0:00.
+        """
+
+        start_date = datetime(2018, 1, 1)
+        end_date = start_date + timedelta(7)
+
+        self.assertEqual(
+            list(tap_braintree.daterange(start_date, end_date)),
+
+            [
+                 (datetime(2018, 1, 1, 0, 0, tzinfo=pytz.UTC), datetime(2018, 1, 2, 0, 0, tzinfo=pytz.UTC))
+                ,(datetime(2018, 1, 2, 0, 0, tzinfo=pytz.UTC), datetime(2018, 1, 3, 0, 0, tzinfo=pytz.UTC))
+                ,(datetime(2018, 1, 3, 0, 0, tzinfo=pytz.UTC), datetime(2018, 1, 4, 0, 0, tzinfo=pytz.UTC))
+                ,(datetime(2018, 1, 4, 0, 0, tzinfo=pytz.UTC), datetime(2018, 1, 5, 0, 0, tzinfo=pytz.UTC))
+                ,(datetime(2018, 1, 5, 0, 0, tzinfo=pytz.UTC), datetime(2018, 1, 6, 0, 0, tzinfo=pytz.UTC))
+                ,(datetime(2018, 1, 6, 0, 0, tzinfo=pytz.UTC), datetime(2018, 1, 7, 0, 0, tzinfo=pytz.UTC))
+                ,(datetime(2018, 1, 7, 0, 0, tzinfo=pytz.UTC), datetime(2018, 1, 8, 0, 0, tzinfo=pytz.UTC))
+                ,(datetime(2018, 1, 8, 0, 0, tzinfo=pytz.UTC), datetime(2018, 1, 9, 0, 0, tzinfo=pytz.UTC))
+            ]
+        )
+
+    def test_daterange_different_times(self):
+        """
+        When given two dates, 7 days apart, with random times within
+        the day, generator should function in the same way as it would
+        have if all the times were 0:00
+        """
+
+        start_date = datetime(2018, 1, 1, 10, 54, 23)
+        end_date = datetime(2018, 1, 8, 2, 12, 45)
+
+        self.assertEqual(
+            list(tap_braintree.daterange(start_date, end_date)),
+
+            [
+                 (datetime(2018, 1, 1, 0, 0, tzinfo=pytz.UTC), datetime(2018, 1, 2, 0, 0, tzinfo=pytz.UTC))
+                ,(datetime(2018, 1, 2, 0, 0, tzinfo=pytz.UTC), datetime(2018, 1, 3, 0, 0, tzinfo=pytz.UTC))
+                ,(datetime(2018, 1, 3, 0, 0, tzinfo=pytz.UTC), datetime(2018, 1, 4, 0, 0, tzinfo=pytz.UTC))
+                ,(datetime(2018, 1, 4, 0, 0, tzinfo=pytz.UTC), datetime(2018, 1, 5, 0, 0, tzinfo=pytz.UTC))
+                ,(datetime(2018, 1, 5, 0, 0, tzinfo=pytz.UTC), datetime(2018, 1, 6, 0, 0, tzinfo=pytz.UTC))
+                ,(datetime(2018, 1, 6, 0, 0, tzinfo=pytz.UTC), datetime(2018, 1, 7, 0, 0, tzinfo=pytz.UTC))
+                ,(datetime(2018, 1, 7, 0, 0, tzinfo=pytz.UTC), datetime(2018, 1, 8, 0, 0, tzinfo=pytz.UTC))
+                ,(datetime(2018, 1, 8, 0, 0, tzinfo=pytz.UTC), datetime(2018, 1, 9, 0, 0, tzinfo=pytz.UTC))
+            ]
+        )
+
+
+if __name__ == '__main__':
+    unittest.main()
+


### PR DESCRIPTION
**Disbursement date replication**
When transactions from Braintree API are updated with disbursement_date, but updated_at field is not updated.

Originally I had thought you could compare the STATE.last_updated_at value with the greater of either updated_at or disbursement_date, but because disbursement_date can be appended up to 3 or 4 days after a transaction is updated, this doesn't work.
Instead, I think the better option is have two replication keys - updated_at and disbursement_details.disbursement_date, each storing the maximum value of each run in the STATE object.

A record will be updated either if the updated_at field is greater than or equal to the latest_updated_at value, or if the disbursement_date value is greater than the latest_disbursement_date value. Disbursement date has to be just greater than (not equal to), because it is only a date value (no time value). This assumes that all transactions that are disbursed on a given date are updated at the same time (confirming with Braintree that this is the case).

**Daily iteration**
The Braintree API only returns a maximum of 20k results per call of the transaction search endpoint. This means if a date range contains more than 20k transactions, the earliest transactions will not be retrieved. This is particularly important in the initial backfill of data.

To solve this, I iterated through days one at a time. It does make the process a little slower - requiring more API calls - but replication is more reliable.

Iterating daily might be too much - it could possibility be a configurable window - but I didn't want to build overly complex date iteration logic or pull in another dependency like dateutil.
