### PR TITLE
Additions to schema - payment_instrument_type,  credit_card_details.card_type and paypal_details object

### DIFF
--- a/tap_braintree/schemas/transactions.json
+++ b/tap_braintree/schemas/transactions.json
@@ -24,6 +24,9 @@
         "amount": {
             "type": ["null", "number"]
         },
+        "payment_instrument_type": {
+            "type": ["null", "string"]
+        },
         "service_fee_amount": {
             "type": ["null", "number"]
         },
@@ -69,6 +72,9 @@
             "type": "object",
             "properties": {
                 "customer_location": {
+                    "type": ["null", "string"]
+                },
+                "card_type": {
                     "type": ["null", "string"]
                 }
             }
@@ -125,6 +131,54 @@
               "type": "null"
             }
           ]
+        },
+        "paypal_details": {
+            "anyOf": [
+                {
+                    "type": "object",
+                    "properties": {
+                        "authorization_id" : {
+                            "type": ["null", "string"]
+                        },
+                        "capture_id": {
+                            "type": ["null", "string"]
+                        },
+                        "payer_email": {
+                            "type": ["null", "string"]
+                        },
+                        "payer_id": {
+                            "type": ["null", "string"]
+                        },
+                        "payer_status": {
+                            "type": ["null", "string"]
+                        },
+                        "payment_id": {
+                            "type": ["null", "string"]
+                        },
+                        "refund_id": {
+                            "type": ["null", "string"]
+                        },
+                        "seller_protection_status": {
+                            "type": ["null", "string"]
+                        },
+                        "tax_id": {
+                            "type": ["null", "string"]
+                        },
+                        "tax_id_type": {
+                            "type": ["null", "string"]
+                        },
+                        "transaction_fee_amount": {
+                            "type": ["null", "string"]
+                        },
+                        "transaction_fee_currency_iso_code": {
+                            "type": ["null", "string"]
+                        }
+                    }
+                },
+                {
+                    "type": "null"
+                }
+            ]
         }
     }
 }


### PR DESCRIPTION
**Schema updates**
I added a few fields to the schema:
* payment_instrument_type
* credit_card_details.card_type
* paypal_details

Paypal details contains Paypal fee amount, which is needed to reconcile Paypal transactions with Paypal deposits (fees are applied with the deposit, while Braintree fees are charged monthly).

