### PR TITLE
Update Disbursement Date Logic

### DIFF
--- a/tap_braintree/__init__.py
+++ b/tap_braintree/__init__.py
@@ -153,7 +153,7 @@ def sync_transactions():
             if (
                 updated_at >= latest_updated_at
             ) or (
-                disbursement_date > latest_disbursement_date
+                disbursement_date >= latest_disbursement_date
             ):
 
                 if updated_at > run_maximum_updated_at:


### PR DESCRIPTION
Running into an issue where only some of the transactions disbursed on a given day are updated. As far as I can tell, not all transactions are updated with a disbursement date at the same time, this means that transactions that are updated later may be missed by subsequent invocations of the tap.

Testing different anchor times hasn't resolved this either and Braintree hasn't yet provided a good answer as to when in the day the transactions will be updated (seems to be between 5 and 9pm PT).

Propose changing the logic to sync records with a disbursement greater than *or equal to* the last run's disbursement date. This will result in more duplicative records but will be more likely to update *all* records.

Volume of daily rows could still be controlled by running the sync less frequently.