### PR TITLE
Adding merchant_account_id to transactions.json.

### DIFF
--- a/tap_braintree/schemas/transactions.json
+++ b/tap_braintree/schemas/transactions.json
@@ -57,6 +57,9 @@
         "currency_iso_code": {
             "type": ["null", "string"]
         },
+        "merchant_account_id": {
+            "type": ["null", "string"]
+        },
         "customer_details": {
             "type": "object",
             "properties": {


### PR DESCRIPTION
This is in reference to #20  

Schema updates:

- merchant_account_id

The merchant account ID is used when creating a transaction. If you have multiple accounts, this column will allow you to know what account the transaction was made for.