### PR TITLE
Update from Braintree SDK 3.34.0 to 3.53.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(name='tap-braintree',
       install_requires=[
           'singer-python==5.0.4',
           'requests==2.20.0',
-          'braintree==3.34.0',
+          'braintree==3.53.0',
       ],
       entry_points='''
           [console_scripts]

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(name='tap-braintree',
       classifiers=['Programming Language :: Python :: 3 :: Only'],
       py_modules=['tap_braintree'],
       install_requires=[
-          'singer-python==5.0.4',
+          'singer-python==5.0.15',
           'requests==2.20.0',
           'braintree==3.53.0',
       ],


### PR DESCRIPTION
The version of Braintree in current use is from Jan 2017. New features
such as ACH are broken in this older version when using the current
APIs. As of Jan 2017, ACH was in a very nascent state and the API has changed such that when trying to sync ACH rows, these fail with the following error:

```
2019-05-09 19:51:59,960Z    tap -   File "/code/orchestrator/tap-env/lib/python3.5/site-packages/braintree/ach_mandate.py", line 10, in __init__
2019-05-09 19:51:59,960Z    tap -     self.accepted_at = datetime.strptime(attributes["accepted_at"], "%Y-%m-%dT%H:%M:%S.%fZ")
2019-05-09 19:51:59,960Z    tap - TypeError: strptime() argument 1 must be str, not datetime.datetime
```

This blocks the synchronization of all row newer than the broken row ACH row.

# Effect
Anyone using this tap that performs ACH transactions will be unable to synchronize data past their first ACH row.

# Solution
This update brings it current to a version released in Spring 2019.

# Verification
I locally ran the pre-PR code and verified the failure. Then ran the PR code and it successfully sync'd the ACH row and the subsequent ones, exiting with a `0` exit code.

**I'm happy to test it out on my own StitchData account but unsure how to facilitate that.**

# Note
Upgraded the singer-python to latest version in order to be able to run this in the same environment as the target-stitch. These were patch level changes.