### PR TITLE
Change exception handling

### DIFF
--- a/tap_braintree/__init__.py
+++ b/tap_braintree/__init__.py
@@ -205,7 +205,8 @@ def do_sync():
     logger.info("Sync completed")
 
 
-def main_impl():
+@utils.handle_top_exception(logger)
+def main():
     args = utils.parse_args(
         ["merchant_id", "public_key", "private_key", "start_date"]
     )
@@ -222,15 +223,12 @@ def main_impl():
     if args.state:
         STATE.update(args.state)
 
-    do_sync()
-
-
-def main():
     try:
-        main_impl()
-    except Exception as exc:
-        logger.critical(exc)
-        raise exc
+        do_sync()
+    except braintree.exceptions.authentication_error.AuthenticationError:
+        logger.critical('Authentication error occured. '
+                        'Please check your merchant_id, public_key, and '
+                        'private_key for errors', exc_info=True)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
- Add specific message for auth errors
- Use `singer-python` for top level exception handling

This PR allows for `AuthenticationErrors` to be caught and handled separate from everything else; where "everything else" gets passed up to the `utils` decorator.

---

Example of old authentication error:
```
CRITICAL                                                                                                                                                                                                                                      Traceback (most recent call last):                                                                                                                                                                                                              File "/opt/code/tap-braintree/tap_braintree/__init__.py", line 227, in main
    do_sync()
  File "/opt/code/tap-braintree/tap_braintree/__init__.py", line 204, in do_sync
    sync_transactions()
  File "/opt/code/tap-braintree/tap_braintree/__init__.py", line 112, in sync_transactions
    braintree.TransactionSearch.created_at.between(start, end))
  File "/usr/local/share/virtualenvs/tap-braintree/lib/python3.5/site-packages/braintree/transaction.py", line 390, in search
    return Configuration.gateway().transaction.search(*query)
  File "/usr/local/share/virtualenvs/tap-braintree/lib/python3.5/site-packages/braintree/transaction_gateway.py", line 84, in search
    response = self.config.http().post(self.config.base_merchant_path() + "/transactions/advanced_search_ids", {"search": self.__criteria(query)})
  File "/usr/local/share/virtualenvs/tap-braintree/lib/python3.5/site-packages/braintree/util/http.py", line 58, in post
    return self._make_request("POST", path, Http.ContentType.Xml, params)
  File "/usr/local/share/virtualenvs/tap-braintree/lib/python3.5/site-packages/braintree/util/http.py", line 88, in _make_request
    Http.raise_exception_from_status(status)
  File "/usr/local/share/virtualenvs/tap-braintree/lib/python3.5/site-packages/braintree/util/http.py", line 37, in raise_exception_from_status
    raise AuthenticationError()
braintree.exceptions.authentication_error.AuthenticationError
```

Example of new authentication error:
```
CRITICAL Authentication error occured. Please check your merchant_id, public_key, and private_key for errors
Traceback (most recent call last):
  File "/opt/code/tap-braintree/tap_braintree/__init__.py", line 227, in main
    do_sync()
  File "/opt/code/tap-braintree/tap_braintree/__init__.py", line 204, in do_sync
    sync_transactions()
  File "/opt/code/tap-braintree/tap_braintree/__init__.py", line 112, in sync_transactions
    braintree.TransactionSearch.created_at.between(start, end))
  File "/usr/local/share/virtualenvs/tap-braintree/lib/python3.5/site-packages/braintree/transaction.py", line 390, in search
    return Configuration.gateway().transaction.search(*query)
  File "/usr/local/share/virtualenvs/tap-braintree/lib/python3.5/site-packages/braintree/transaction_gateway.py", line 84, in search
    response = self.config.http().post(self.config.base_merchant_path() + "/transactions/advanced_search_ids", {"search": self.__criteria(query)})
  File "/usr/local/share/virtualenvs/tap-braintree/lib/python3.5/site-packages/braintree/util/http.py", line 58, in post
    return self._make_request("POST", path, Http.ContentType.Xml, params)
  File "/usr/local/share/virtualenvs/tap-braintree/lib/python3.5/site-packages/braintree/util/http.py", line 88, in _make_request
    Http.raise_exception_from_status(status)
  File "/usr/local/share/virtualenvs/tap-braintree/lib/python3.5/site-packages/braintree/util/http.py", line 37, in raise_exception_from_status
    raise AuthenticationError()
braintree.exceptions.authentication_error.AuthenticationError
```

---

Example of not-an-authentication-error:
```
CRITICAL
Traceback (most recent call last):
  File "/usr/local/share/virtualenvs/tap-braintree/bin/tap-braintree", line 11, in <module>
    load_entry_point('tap-braintree', 'console_scripts', 'tap-braintree')()
  File "/usr/local/share/virtualenvs/tap-braintree/lib/python3.5/site-packages/singer/utils.py", line 225, in wrapped
    return fnc(*args, **kwargs)
  File "/opt/code/tap-braintree/tap_braintree/__init__.py", line 228, in main
    do_sync()
  File "/opt/code/tap-braintree/tap_braintree/__init__.py", line 203, in do_sync
    raise RuntimeError
RuntimeError
```