### PR TITLE
Add subscription_id to transactions.json

### DIFF
--- a/tap_braintree/schemas/transactions.json
+++ b/tap_braintree/schemas/transactions.json
@@ -60,6 +60,9 @@
         "merchant_account_id": {
             "type": ["null", "string"]
         },
+        "subscription_id": {
+            "type": ["null", "string"]
+        },
         "customer_details": {
             "type": "object",
             "properties": {


### PR DESCRIPTION
# Description of change
Adds subscription_id to transactions.json and addresses https://github.com/singer-io/tap-braintree/issues/9. 

# Manual QA steps
 - Tested locally and works.
 
# Risks
 - None that I can think of.
 
# Rollback steps
 - revert this branch
