### PR TITLE
do not add dates later than end date to state file

### DIFF
--- a/tap_braintree/__init__.py
+++ b/tap_braintree/__init__.py
@@ -185,9 +185,9 @@ def sync_transactions():
         run_maximum_disbursement_date
     ))
 
-    latest_updated_at = run_maximum_updated_at
+    latest_updated_at = min(run_maximum_updated_at, period_end)
 
-    latest_disbursement_date = run_maximum_disbursement_date
+    latest_disbursement_date = min(run_maximum_disbursement_date, period_end)
 
     STATE['latest_updated_at'] = utils.strftime(latest_updated_at)
 


### PR DESCRIPTION
# Description of change
 - Restrict the dates in the state file to be earlier or equal to the end date of each extraction. This way records will not be missed as described in https://github.com/singer-io/tap-braintree/issues/28.

# Manual QA steps
 - Ran the tap locally with no errors.
 - Config file:
```
{"merchant_id": "<<my_merchant_id>>",
 "public_key": "<<my_public_key>>",
 "private_key": "<<my_private_key>>",
 "start_date": "2020-03-11T00:00:00Z"
}
```
 
# Risks
 - Tap will output more data than before - records with created_at before the tap's runtime, but an updated_at after the tap's runtime will be pushed again on the subsequent tap run.
 - But it is better for the tap to guarantee at least one push for each record, than at most one push for each record
 
# Rollback steps
 - revert this branch
