### PR TITLE
Add masked_number to credit_card_details

### DIFF
--- a/tap_braintree/schemas/transactions.json
+++ b/tap_braintree/schemas/transactions.json
@@ -82,6 +82,9 @@
                 },
                 "card_type": {
                     "type": ["null", "string"]
+                },
+                "masked_number": {
+                    "type": ["null", "string"]
                 }
             }
         },


### PR DESCRIPTION
# Description of change
Hi! Could we add masked_number to credit_card_details? (https://developers.braintreepayments.com/reference/response/transaction/ruby#credit_card_details.masked_number)
I'm looking to merge data from two different sources using it.

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
