### PR TITLE
Added purchase_order_number to transactions.json

### DIFF
--- a/tap_braintree/schemas/transactions.json
+++ b/tap_braintree/schemas/transactions.json
@@ -63,6 +63,9 @@
         "subscription_id": {
             "type": ["null", "string"]
         },
+        "purchase_order_number": {
+            "type": ["null", "string"]
+        },
         "customer_details": {
             "type": "object",
             "properties": {


### PR DESCRIPTION
# Description of change
type: null/string
 Description from api reference: 
"purchaseOrderNumber: String
A purchase order identification value you associate with this transaction."

# Manual QA steps
 - tested locally
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
