### PR TITLE
Update braintree SDK version to 4.18.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,8 +1,13 @@
-version: 2
+version: 2.1
+
+executors:
+  docker-executor:
+    docker:
+      - image: 218546966473.dkr.ecr.us-east-1.amazonaws.com/circle-ci:stitch-tap-tester
+
 jobs:
   build:
-    docker:
-      - image: 218546966473.dkr.ecr.us-east-1.amazonaws.com/circle-ci:tap-tester
+    executor: docker-executor
     steps:
       - checkout
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ jobs:
           name: 'Pylint'
           command: |
             source /usr/local/share/virtualenvs/tap-braintree/bin/activate
-            pylint tap_braintree --disable missing-docstring,logging-format-interpolation,no-member,broad-except,redefined-variable-type,too-many-branches,too-few-public-methods,wrong-import-order,too-many-locals,line-too-long,invalid-name,bare-except,no-else-raise,cyclic-import,bad-continuation,undefined-loop-variable
+            pylint tap_braintree --disable missing-docstring,logging-format-interpolation,no-member,broad-except,redefined-variable-type,too-many-branches,too-few-public-methods,wrong-import-order,too-many-locals,line-too-long,invalid-name,bare-except,no-else-raise,cyclic-import,bad-continuation,undefined-loop-variable,consider-using-f-string
       - run:
           name: 'Unit Tests'
           command: |

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(name='tap-braintree',
       install_requires=[
           'singer-python==5.5.0',
           'requests==2.20.0',
-          'braintree==3.53.0',
+          'braintree==4.18.1',
       ],
       extras_require={
           'dev': [


### PR DESCRIPTION
# Description of change
Update braintree SDK to `v4.18.1`. `v3.53.0` will be unsupported in March 2023.
No changes to the tap code.

[Braintree SDK changelog](https://github.com/braintree/braintree_python/blob/master/CHANGELOG.md)
[Migration Guide](https://developer.paypal.com/braintree/docs/reference/general/server-sdk-migration-guide/python)

# Manual QA steps
 - Created sandbox account to verify syncs still function as expected.
 
# Risks
 - Possible that some change to the SDK may have been made that we did could not catch with limited test data. Tap never did anything complex enough to warrant updating any code updates according the Braintree's migration guide.
 
# Rollback steps
 - revert this branch
