### PR TITLE
SAC-27537 - fix: timeout and backoff issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,11 +30,13 @@ This tap:
 3. Create the config file
 
     Create a JSON file called `config.json` containing the Merchant ID, Public Key and Private Key.
+    An optional parameter, request_timeout, may also be included to specify a custom timeout (in seconds) for API requests.
 
     ```json
     {"merchant_id": "your-merchant-id",
      "public_key": "your-public-key",
-     "private_key": "your-private-key"}
+     "private_key": "your-private-key",
+     "request_timeout": 200}
     ```
 
 4. [Optional] Create the initial state file

--- a/tap_braintree/__init__.py
+++ b/tap_braintree/__init__.py
@@ -258,7 +258,7 @@ def main():
         request_timeout = float(config.pop("request_timeout", REQUEST_TIMEOUT))
 
         if request_timeout <= 0:
-            logger.info("Invalid value for request_timeout parameter, reverting to default setting.")
+            logger.warn("Invalid value for request_timeout parameter, reverting to default setting.")
             request_timeout = REQUEST_TIMEOUT
     except ValueError:
         raise ValueError('Please provide a value greater than 0 for the request_timeout parameter in config')

--- a/tap_braintree/__init__.py
+++ b/tap_braintree/__init__.py
@@ -257,9 +257,9 @@ def main():
         # Take value of request_timeout if provided in config else take default value
         request_timeout = float(config.pop("request_timeout", REQUEST_TIMEOUT))
 
-        if request_timeout == 0:
-            # Raise error when request_timeout is given as 0 in config
-            raise ValueError()
+        if request_timeout <= 0:
+            logger.info("Invalid value for request_timeout parameter, reverting to default setting.")
+            request_timeout = REQUEST_TIMEOUT
     except ValueError:
         raise ValueError('Please provide a value greater than 0 for the request_timeout parameter in config')
 

--- a/tap_braintree/__init__.py
+++ b/tap_braintree/__init__.py
@@ -258,12 +258,12 @@ def main():
         request_timeout = float(config.pop("request_timeout", REQUEST_TIMEOUT))
 
         if request_timeout == 0:
-            logger.warn("Invalid value for request_timeout parameter, reverting to default setting.")
+            logger.warn(f"Invalid value for request_timeout parameter, reverting to default value {REQUEST_TIMEOUT}")
             request_timeout = REQUEST_TIMEOUT
         elif request_timeout < 0:
             raise ValueError()
     except ValueError:
-        raise ValueError('Please provide a positive value for the request_timeout parameter in config')
+        raise ValueError("Please provide a positive value for the request_timeout parameter in config")
 
     environment = getattr(
         braintree.Environment, config.pop("environment", "Production")

--- a/tap_braintree/__init__.py
+++ b/tap_braintree/__init__.py
@@ -258,7 +258,7 @@ def main():
 
     try:
         # Take value of request_timeout if provided in config else take default value
-        request_timeout = float(config.get("request_timeout", REQUEST_TIMEOUT))
+        request_timeout = float(config.pop("request_timeout", REQUEST_TIMEOUT))
 
         if request_timeout == 0:
             # Raise error when request_timeout is given as 0 in config

--- a/tap_braintree/__init__.py
+++ b/tap_braintree/__init__.py
@@ -14,7 +14,7 @@ from singer import utils
 from tap_braintree.discover import discover
 from .transform import transform_row
 
-TIME_OUT = 300
+REQUEST_TIMEOUT = 300
 
 CONFIG = {}
 STATE = {}
@@ -221,20 +221,20 @@ def main():
     config = args.config
 
     try:
-        # Take value of timeout if provided in config else take default value
-        timeout = float(config.get("timeout", TIME_OUT))
+        # Take value of request_timeout if provided in config else take default value
+        request_timeout = float(config.get("request_timeout", REQUEST_TIMEOUT))
 
-        if timeout == 0:
-            # Raise error when timeout is given as 0 in config
+        if request_timeout == 0:
+            # Raise error when request_timeout is given as 0 in config
             raise ValueError()
     except ValueError:
-        raise ValueError('Please provide a value greater than 0 for the timeout parameter in config')
+        raise ValueError('Please provide a value greater than 0 for the request_timeout parameter in config')
 
     environment = getattr(
         braintree.Environment, config.pop("environment", "Production")
     )
 
-    config["timeout"] = timeout
+    config["timeout"] = request_timeout
     CONFIG['start_date'] = config.pop('start_date')
 
     braintree.Configuration.configure(environment, **config)

--- a/tap_braintree/__init__.py
+++ b/tap_braintree/__init__.py
@@ -84,9 +84,6 @@ def daterange(start_date, end_date):
         yield start_date + timedelta(n), start_date + timedelta(n + 1)
 
 
-# Backoff the request for 5 times when ConnectionError, TooManyRequestsError (status code = 429),
-# ServerError(status code = 500, 502) , ServiceUnavailableError (status code = 503) ,
-# or GatewayTimeoutError (status code = 504) occurs
 @backoff.on_exception(
     backoff.expo,
     (
@@ -239,7 +236,11 @@ def do_discover():
 
     logger.info("Starting discovery")
     catalog = discover()
-    json.dump(catalog, sys.stdout, indent=2)
+
+    sys.stdout.reconfigure(encoding='utf-8')
+    json.dump(catalog, sys.stdout, indent=2, ensure_ascii=False)
+
+    # json.dump(catalog, sys.stdout, indent=2)
     logger.info("Finished discover")
 
 

--- a/tap_braintree/__init__.py
+++ b/tap_braintree/__init__.py
@@ -236,11 +236,7 @@ def do_discover():
 
     logger.info("Starting discovery")
     catalog = discover()
-
-    sys.stdout.reconfigure(encoding='utf-8')
-    json.dump(catalog, sys.stdout, indent=2, ensure_ascii=False)
-
-    # json.dump(catalog, sys.stdout, indent=2)
+    json.dump(catalog, sys.stdout, indent=2)
     logger.info("Finished discover")
 
 

--- a/tap_braintree/__init__.py
+++ b/tap_braintree/__init__.py
@@ -257,11 +257,13 @@ def main():
         # Take value of request_timeout if provided in config else take default value
         request_timeout = float(config.pop("request_timeout", REQUEST_TIMEOUT))
 
-        if request_timeout <= 0:
+        if request_timeout == 0:
             logger.warn("Invalid value for request_timeout parameter, reverting to default setting.")
             request_timeout = REQUEST_TIMEOUT
+        elif request_timeout < 0:
+            raise ValueError()
     except ValueError:
-        raise ValueError('Please provide a value greater than 0 for the request_timeout parameter in config')
+        raise ValueError('Please provide a positive value for the request_timeout parameter in config')
 
     environment = getattr(
         braintree.Environment, config.pop("environment", "Production")

--- a/tap_braintree/__init__.py
+++ b/tap_braintree/__init__.py
@@ -14,6 +14,7 @@ from singer import utils
 from tap_braintree.discover import discover
 from .transform import transform_row
 
+TIME_OUT = 300
 
 CONFIG = {}
 STATE = {}
@@ -222,10 +223,21 @@ def main():
     )
     config = args.config
 
+    try:
+        # Take value of timeout if provided in config else take default value
+        timeout = float(config.get("timeout", TIME_OUT))
+
+        if timeout == 0:
+            # Raise error when timeout is given as 0 in config
+            raise ValueError()
+    except ValueError:
+        raise ValueError('Please provide a value greater than 0 for the timeout parameter in config')
+
     environment = getattr(
         braintree.Environment, config.pop("environment", "Production")
     )
 
+    config["timeout"] = timeout
     CONFIG['start_date'] = config.pop('start_date')
 
     braintree.Configuration.configure(environment, **config)

--- a/tests/test_backoff.py
+++ b/tests/test_backoff.py
@@ -5,17 +5,28 @@ from braintree.exceptions import ServerError
 
 
 class TestGetTransactionsDataBackoff(unittest.TestCase):
-    # @mock.patch("tap_braintree.__init__.get_transactions_data")
     @mock.patch("tap_braintree.braintree.Transaction.search")
     def test_retries_on_server_error(
         self,
-        mock_transaction_search,
-        # mock_get_transactions_data
+        mock_transaction_search
     ):
         # Configure the mock to raise ServerError on the first two calls, then succeed
         mock_transaction_search.side_effect = [ServerError(), ServerError(), "success"]
-
         result = get_transactions_data("2021-01-01", "2021-01-31")
 
         self.assertEqual(result, "success")
-        # self.assertEqual(mock_get_transactions_data.call_count, 3)
+        self.assertEqual(mock_transaction_search.call_count, 3)
+
+    @mock.patch("tap_braintree.braintree.Transaction.search")
+    def test_max_retries_reached(
+        self,
+        mock_transaction_search
+    ):
+        # Configure the mock to always raise ServerError
+        mock_transaction_search.side_effect = ServerError()
+
+        with self.assertRaises(ServerError):
+            get_transactions_data("2021-01-01", "2021-01-31")
+
+        # Assuming the backoff decorator is set to max_tries=5
+        self.assertEqual(mock_transaction_search.call_count, 5)

--- a/tests/test_backoff.py
+++ b/tests/test_backoff.py
@@ -10,7 +10,9 @@ class TestGetTransactionsDataBackoff(unittest.TestCase):
         self,
         mock_transaction_search
     ):
-        # Configure the mock to raise ServerError on the first two calls, then succeed
+        """
+        Test that get_transactions_data retries on transient ServerError and succeeds after retries.
+        """
         mock_transaction_search.side_effect = [ServerError(), ServerError(), "success"]
         result = get_transactions_data("2021-01-01", "2021-01-31")
 
@@ -22,11 +24,12 @@ class TestGetTransactionsDataBackoff(unittest.TestCase):
         self,
         mock_transaction_search
     ):
-        # Configure the mock to always raise ServerError
+        """
+        Test that get_transactions_data raises ServerError after exceeding maximum retry attempts.
+        """
         mock_transaction_search.side_effect = ServerError()
 
         with self.assertRaises(ServerError):
             get_transactions_data("2021-01-01", "2021-01-31")
 
-        # Assuming the backoff decorator is set to max_tries=5
         self.assertEqual(mock_transaction_search.call_count, 5)

--- a/tests/test_backoff.py
+++ b/tests/test_backoff.py
@@ -1,0 +1,19 @@
+import unittest
+from unittest import mock
+from tap_braintree import get_transactions_data
+from braintree.exceptions import ServerError
+
+
+class TestGetTransactionsDataBackoff(unittest.TestCase):
+    @mock.patch("tap_braintree.__init__.get_transactions_data")
+    @mock.patch("tap_braintree.__init__.braintree.Transaction.search")
+    def test_retries_on_server_error(
+        self, mock_transaction_search, mock_get_transactions_data
+    ):
+        # Configure the mock to raise ServerError on the first two calls, then succeed
+        mock_transaction_search.side_effect = [ServerError(), ServerError(), "success"]
+
+        result = get_transactions_data("2021-01-01", "2021-01-31")
+
+        self.assertEqual(result, "success")
+        # self.assertEqual(mock_get_transactions_data.call_count, 3)

--- a/tests/test_backoff.py
+++ b/tests/test_backoff.py
@@ -5,10 +5,12 @@ from braintree.exceptions import ServerError
 
 
 class TestGetTransactionsDataBackoff(unittest.TestCase):
-    @mock.patch("tap_braintree.__init__.get_transactions_data")
-    @mock.patch("tap_braintree.__init__.braintree.Transaction.search")
+    # @mock.patch("tap_braintree.__init__.get_transactions_data")
+    @mock.patch("tap_braintree.braintree.Transaction.search")
     def test_retries_on_server_error(
-        self, mock_transaction_search, mock_get_transactions_data
+        self,
+        mock_transaction_search,
+        # mock_get_transactions_data
     ):
         # Configure the mock to raise ServerError on the first two calls, then succeed
         mock_transaction_search.side_effect = [ServerError(), ServerError(), "success"]

--- a/tests/test_backoff.py
+++ b/tests/test_backoff.py
@@ -6,10 +6,7 @@ from braintree.exceptions import ServerError
 
 class TestGetTransactionsDataBackoff(unittest.TestCase):
     @mock.patch("tap_braintree.braintree.Transaction.search")
-    def test_retries_on_server_error(
-        self,
-        mock_transaction_search
-    ):
+    def test_retries_on_server_error(self, mock_transaction_search):
         """
         Test that get_transactions_data retries on transient ServerError and succeeds after retries.
         """
@@ -20,10 +17,7 @@ class TestGetTransactionsDataBackoff(unittest.TestCase):
         self.assertEqual(mock_transaction_search.call_count, 3)
 
     @mock.patch("tap_braintree.braintree.Transaction.search")
-    def test_max_retries_reached(
-        self,
-        mock_transaction_search
-    ):
+    def test_max_retries_reached(self, mock_transaction_search):
         """
         Test that get_transactions_data raises ServerError after exceeding maximum retry attempts.
         """

--- a/tests/test_backoff.py
+++ b/tests/test_backoff.py
@@ -1,7 +1,11 @@
 import unittest
 from unittest import mock
 from tap_braintree import get_transactions_data
+
+from braintree.exceptions.too_many_requests_error import TooManyRequestsError
 from braintree.exceptions import ServerError
+from braintree.exceptions.service_unavailable_error import ServiceUnavailableError
+from braintree.exceptions.gateway_timeout_error import GatewayTimeoutError
 
 
 class TestGetTransactionsDataBackoff(unittest.TestCase):
@@ -27,3 +31,69 @@ class TestGetTransactionsDataBackoff(unittest.TestCase):
             get_transactions_data("2021-01-01", "2021-01-31")
 
         self.assertEqual(mock_transaction_search.call_count, 5)
+
+    @mock.patch("tap_braintree.braintree.Transaction.search")
+    def test_retries_on_connection_error(self, mock_transaction_search):
+        """
+        Test retries on ConnectionError and succeeds after retry.
+        """
+        mock_transaction_search.side_effect = [ConnectionError(), "success"]
+        result = get_transactions_data("2021-01-01", "2021-01-31")
+        self.assertEqual(result, "success")
+        self.assertEqual(mock_transaction_search.call_count, 2)
+
+    @mock.patch("tap_braintree.braintree.Transaction.search")
+    def test_retries_on_too_many_requests_error(self, mock_transaction_search):
+        """
+        Test retries on TooManyRequestsError and succeeds.
+        """
+        mock_transaction_search.side_effect = [TooManyRequestsError(), "success"]
+        result = get_transactions_data("2021-01-01", "2021-01-31")
+        self.assertEqual(result, "success")
+        self.assertEqual(mock_transaction_search.call_count, 2)
+
+    @mock.patch("tap_braintree.braintree.Transaction.search")
+    def test_retries_on_service_unavailable_error(self, mock_transaction_search):
+        """
+        Test retries on ServiceUnavailableError.
+        """
+        mock_transaction_search.side_effect = [ServiceUnavailableError(), "success"]
+        result = get_transactions_data("2021-01-01", "2021-01-31")
+        self.assertEqual(result, "success")
+        self.assertEqual(mock_transaction_search.call_count, 2)
+
+    @mock.patch("tap_braintree.braintree.Transaction.search")
+    def test_retries_on_gateway_timeout_error(self, mock_transaction_search):
+        """
+        Test retries on GatewayTimeoutError and returns result.
+        """
+        mock_transaction_search.side_effect = [GatewayTimeoutError(), "success"]
+        result = get_transactions_data("2021-01-01", "2021-01-31")
+        self.assertEqual(result, "success")
+        self.assertEqual(mock_transaction_search.call_count, 2)
+
+    @mock.patch("tap_braintree.braintree.Transaction.search")
+    def test_does_not_retry_on_unlisted_exception(self, mock_transaction_search):
+        """
+        Test that an unlisted exception does not trigger retry.
+        """
+        class CustomException(Exception):
+            pass
+
+        mock_transaction_search.side_effect = CustomException("unexpected")
+
+        with self.assertRaises(CustomException):
+            get_transactions_data("2021-01-01", "2021-01-31")
+
+        self.assertEqual(mock_transaction_search.call_count, 1)
+
+    @mock.patch("tap_braintree.braintree.Transaction.search")
+    def test_success_without_error(self, mock_transaction_search):
+        """
+        Test function succeeds without any exception.
+        """
+        mock_transaction_search.return_value = "success"
+
+        result = get_transactions_data("2021-01-01", "2021-01-31")
+        self.assertEqual(result, "success")
+        self.assertEqual(mock_transaction_search.call_count, 1)

--- a/tests/test_timeout.py
+++ b/tests/test_timeout.py
@@ -3,14 +3,15 @@ from unittest import mock
 from tap_braintree import main
 
 
-class Mocked():
-    ''' Class to initialize required variables'''
+class Mocked:
+    """Class to initialize required variables"""
+
     def __init__(self):
         self.config = {
             "merchant_id": "test",
             "public_key": "test",
             "private_key": "test",
-            "start_date": "2017-01-17T20:32:05Z"
+            "start_date": "2017-01-17T20:32:05Z",
         }
         self.state = {}
         self.catalog = {}
@@ -23,14 +24,16 @@ class Mocked():
 @mock.patch("tap_braintree.braintree.Configuration.configure")
 @mock.patch("tap_braintree.utils.parse_args")
 class TestTimeout(unittest.TestCase):
-    '''
+    """
     Test class to validate fetched request_timeout value
-    '''
+    """
 
-    def test_timeout_invalid_value_zero_integer(self, mocked_parse_args, mocked_configure, mocked_discover, mocked_environment):
-        '''
+    def test_timeout_invalid_value_zero_integer(
+        self, mocked_parse_args, mocked_configure, mocked_discover, mocked_environment
+    ):
+        """
         Test zero integer request_timeout should raise ValueError
-        '''
+        """
         mocked_obj = Mocked()
         mocked_obj.config.update({"request_timeout": 0})
         mocked_parse_args.return_value = mocked_obj
@@ -39,27 +42,42 @@ class TestTimeout(unittest.TestCase):
         with self.assertRaises(ValueError) as e:
             main()
 
-        self.assertEqual(str(e.exception), "Please provide a value greater than 0 for the request_timeout parameter in config")
+        self.assertEqual(
+            str(e.exception),
+            "Please provide a value greater than 0 for the request_timeout parameter in config",
+        )
 
-    def test_timeout_invalid_value_string_zero(self, mocked_parse_args, mocked_configure, mocked_discover, mocked_environment):
+    def test_timeout_invalid_value_string_zero(
+        self, mocked_parse_args, mocked_configure, mocked_discover, mocked_environment
+    ):
         mocked_obj = Mocked()
         mocked_obj.config.update({"request_timeout": "0"})
         mocked_parse_args.return_value = mocked_obj
         mocked_environment.return_value = mocked_obj
         with self.assertRaises(ValueError) as e:
             main()
-        self.assertEqual(str(e.exception), "Please provide a value greater than 0 for the request_timeout parameter in config")
+        self.assertEqual(
+            str(e.exception),
+            "Please provide a value greater than 0 for the request_timeout parameter in config",
+        )
 
-    def test_timeout_invalid_value_invalid_string(self, mocked_parse_args, mocked_configure, mocked_discover, mocked_environment):
+    def test_timeout_invalid_value_invalid_string(
+        self, mocked_parse_args, mocked_configure, mocked_discover, mocked_environment
+    ):
         mocked_obj = Mocked()
         mocked_obj.config.update({"request_timeout": "abc"})
         mocked_parse_args.return_value = mocked_obj
         mocked_environment.return_value = mocked_obj
         with self.assertRaises(ValueError) as e:
             main()
-        self.assertEqual(str(e.exception), "Please provide a value greater than 0 for the request_timeout parameter in config")
+        self.assertEqual(
+            str(e.exception),
+            "Please provide a value greater than 0 for the request_timeout parameter in config",
+        )
 
-    def test_timeout_no_value_in_config(self, mocked_parse_args, mocked_configure, mocked_discover, mocked_environment):
+    def test_timeout_no_value_in_config(
+        self, mocked_parse_args, mocked_configure, mocked_discover, mocked_environment
+    ):
         """
         Test when request_timeout is not provided in config
         """
@@ -76,5 +94,5 @@ class TestTimeout(unittest.TestCase):
             merchant_id="test",
             public_key="test",
             private_key="test",
-            timeout=300.0
+            timeout=300.0,
         )

--- a/tests/test_timeout.py
+++ b/tests/test_timeout.py
@@ -78,7 +78,7 @@ class TestTimeout(unittest.TestCase):
             main()
         self.assertEqual(
             str(e.exception),
-            "Please provide a value greater than 0 for the request_timeout parameter in config",
+            "Please provide a positive value for the request_timeout parameter in config",
         )
 
     def test_timeout_no_value_in_config(
@@ -103,29 +103,9 @@ class TestTimeout(unittest.TestCase):
             timeout=300.0,
         )
 
-    def test_timeout_valid_string_type_value_in_config(
+    def test_timeout_negative_string(
         self, mocked_parse_args, mocked_configure, mocked_discover, mocked_environment
     ):
-        """
-        Test when request_timeout is provided as a string in config
-        """
-        mocked_obj = Mocked()
-        mocked_obj.config.update({"request_timeout": "200", "environment": "Sandbox"})
-
-        mocked_parse_args.return_value = mocked_obj
-        mocked_environment.return_value = mocked_obj
-
-        main()
-
-        mocked_configure.assert_called_with(
-            mocked_environment.Sandbox,
-            merchant_id="test",
-            public_key="test",
-            private_key="test",
-            timeout=200.0,
-        )
-
-    def test_timeout_negative_string(self, mocked_parse_args, mocked_configure, mocked_discover, mocked_environment):
         """
         Test request_timeout as negative string falls back to default.
         """
@@ -134,51 +114,27 @@ class TestTimeout(unittest.TestCase):
         mocked_parse_args.return_value = mocked_obj
         mocked_environment.return_value = mocked_obj
 
-        main()
-        mocked_configure.assert_called_with(
-            mocked_environment.Sandbox,
-            merchant_id="test",
-            public_key="test",
-            private_key="test",
-            timeout=300,
+        with self.assertRaises(ValueError) as e:
+            main()
+        self.assertEqual(
+            str(e.exception),
+            "Please provide a positive value for the request_timeout parameter in config",
         )
 
-    def test_timeout_negative_integer(self, mocked_parse_args, mocked_configure, mocked_discover, mocked_environment):
+    def test_timeout_negative_integer(
+        self, mocked_parse_args, mocked_configure, mocked_discover, mocked_environment
+    ):
         """
         Test request_timeout as negative integer falls back to default.
         """
         mocked_obj = Mocked()
-        mocked_obj.config.update({"request_timeout": "-5", "environment": "Sandbox"})
+        mocked_obj.config.update({"request_timeout": -5, "environment": "Sandbox"})
         mocked_parse_args.return_value = mocked_obj
         mocked_environment.return_value = mocked_obj
 
-        main()
-        mocked_configure.assert_called_with(
-            mocked_environment.Sandbox,
-            merchant_id="test",
-            public_key="test",
-            private_key="test",
-            timeout=300,
-        )
-
-    def test_timeout_valid_integer_type_value_in_config(
-        self, mocked_parse_args, mocked_configure, mocked_discover, mocked_environment
-    ):
-        """
-        Test when request_timeout is provided as an integer in config
-        """
-        mocked_obj = Mocked()
-        mocked_obj.config.update({"request_timeout": 200, "environment": "Sandbox"})
-
-        mocked_parse_args.return_value = mocked_obj
-        mocked_environment.return_value = mocked_obj
-
-        main()
-
-        mocked_configure.assert_called_with(
-            mocked_environment.Sandbox,
-            merchant_id="test",
-            public_key="test",
-            private_key="test",
-            timeout=200.0,
+        with self.assertRaises(ValueError) as e:
+            main()
+        self.assertEqual(
+            str(e.exception),
+            "Please provide a positive value for the request_timeout parameter in config",
         )

--- a/tests/test_timeout.py
+++ b/tests/test_timeout.py
@@ -96,3 +96,47 @@ class TestTimeout(unittest.TestCase):
             private_key="test",
             timeout=300.0,
         )
+
+    def test_timeout_valid_string_type_value_in_config(
+        self, mocked_parse_args, mocked_configure, mocked_discover, mocked_environment
+    ):
+        """
+        Test when request_timeout is provided as a string in config
+        """
+        mocked_obj = Mocked()
+        mocked_obj.config.update({"request_timeout": "200", "environment": "Sandbox"})
+
+        mocked_parse_args.return_value = mocked_obj
+        mocked_environment.return_value = mocked_obj
+
+        main()
+
+        mocked_configure.assert_called_with(
+            mocked_environment.Sandbox,
+            merchant_id="test",
+            public_key="test",
+            private_key="test",
+            timeout=200.0,
+        )
+
+    def test_timeout_valid_integer_type_value_in_config(
+        self, mocked_parse_args, mocked_configure, mocked_discover, mocked_environment
+    ):
+        """
+        Test when request_timeout is provided as an integer in config
+        """
+        mocked_obj = Mocked()
+        mocked_obj.config.update({"request_timeout": 200, "environment": "Sandbox"})
+
+        mocked_parse_args.return_value = mocked_obj
+        mocked_environment.return_value = mocked_obj
+
+        main()
+
+        mocked_configure.assert_called_with(
+            mocked_environment.Sandbox,
+            merchant_id="test",
+            public_key="test",
+            private_key="test",
+            timeout=200.0,
+        )

--- a/tests/test_timeout.py
+++ b/tests/test_timeout.py
@@ -32,33 +32,39 @@ class TestTimeout(unittest.TestCase):
         self, mocked_parse_args, mocked_configure, mocked_discover, mocked_environment
     ):
         """
-        Test zero integer request_timeout should raise ValueError
+        Test zero integer request_timeout should fallback on default value
         """
         mocked_obj = Mocked()
-        mocked_obj.config.update({"request_timeout": 0})
+        mocked_obj.config.update({"request_timeout": 0, "environment": "Sandbox"})
         mocked_parse_args.return_value = mocked_obj
         mocked_environment.return_value = mocked_obj
 
-        with self.assertRaises(ValueError) as e:
-            main()
+        main()
 
-        self.assertEqual(
-            str(e.exception),
-            "Please provide a value greater than 0 for the request_timeout parameter in config",
+        mocked_configure.assert_called_with(
+            mocked_environment.Sandbox,
+            merchant_id="test",
+            public_key="test",
+            private_key="test",
+            timeout=300,
         )
 
     def test_timeout_invalid_value_string_zero(
         self, mocked_parse_args, mocked_configure, mocked_discover, mocked_environment
     ):
         mocked_obj = Mocked()
-        mocked_obj.config.update({"request_timeout": "0"})
+        mocked_obj.config.update({"request_timeout": "0", "environment": "Sandbox"})
         mocked_parse_args.return_value = mocked_obj
         mocked_environment.return_value = mocked_obj
-        with self.assertRaises(ValueError) as e:
-            main()
-        self.assertEqual(
-            str(e.exception),
-            "Please provide a value greater than 0 for the request_timeout parameter in config",
+
+        main()
+
+        mocked_configure.assert_called_with(
+            mocked_environment.Sandbox,
+            merchant_id="test",
+            public_key="test",
+            private_key="test",
+            timeout=300,
         )
 
     def test_timeout_invalid_value_invalid_string(

--- a/tests/test_timeout.py
+++ b/tests/test_timeout.py
@@ -24,84 +24,44 @@ class Mocked():
 @mock.patch("tap_braintree.utils.parse_args")
 class TestTimeout(unittest.TestCase):
     '''
-    Test class to validate fetched timeout value
+    Test class to validate fetched request_timeout value
     '''
 
     def test_timeout_invalid_value_zero_integer(self, mocked_parse_args, mocked_configure, mocked_discover, mocked_environment):
         '''
-        Test zero integer timeout should raise ValueError
+        Test zero integer request_timeout should raise ValueError
         '''
         mocked_obj = Mocked()
-        mocked_obj.config.update({"timeout": 0})
+        mocked_obj.config.update({"request_timeout": 0})
         mocked_parse_args.return_value = mocked_obj
         mocked_environment.return_value = mocked_obj
 
         with self.assertRaises(ValueError) as e:
             main()
 
-        self.assertEqual(str(e.exception), "Please provide a value greater than 0 for the timeout parameter in config")
+        self.assertEqual(str(e.exception), "Please provide a value greater than 0 for the request_timeout parameter in config")
 
     def test_timeout_invalid_value_string_zero(self, mocked_parse_args, mocked_configure, mocked_discover, mocked_environment):
         mocked_obj = Mocked()
-        mocked_obj.config.update({"timeout": "0"})
+        mocked_obj.config.update({"request_timeout": "0"})
         mocked_parse_args.return_value = mocked_obj
         mocked_environment.return_value = mocked_obj
         with self.assertRaises(ValueError) as e:
             main()
-        self.assertEqual(str(e.exception), "Please provide a value greater than 0 for the timeout parameter in config")
+        self.assertEqual(str(e.exception), "Please provide a value greater than 0 for the request_timeout parameter in config")
 
     def test_timeout_invalid_value_invalid_string(self, mocked_parse_args, mocked_configure, mocked_discover, mocked_environment):
         mocked_obj = Mocked()
-        mocked_obj.config.update({"timeout": "abc"})
+        mocked_obj.config.update({"request_timeout": "abc"})
         mocked_parse_args.return_value = mocked_obj
         mocked_environment.return_value = mocked_obj
         with self.assertRaises(ValueError) as e:
             main()
-        self.assertEqual(str(e.exception), "Please provide a value greater than 0 for the timeout parameter in config")
-
-    def test_timeout_valid_string_type_value_in_config(self, mocked_parse_args, mocked_configure, mocked_discover, mocked_environment):
-        """
-        Test when timeout is provided as a string in config
-        """
-        mocked_obj = Mocked()
-        mocked_obj.config.update({"timeout": "200", "environment": "Sandbox"})
-
-        mocked_parse_args.return_value = mocked_obj
-        mocked_environment.return_value = mocked_obj
-
-        main()
-
-        mocked_configure.assert_called_with(
-            mocked_environment.Sandbox,
-            merchant_id="test",
-            public_key="test",
-            private_key="test",
-            timeout=200.0
-        )
-
-    def test_timeout_valid_integer_type_value_in_config(self, mocked_parse_args, mocked_configure, mocked_discover, mocked_environment):
-        """
-        Test when timeout is provided as an integer in config
-        """
-        mocked_obj = Mocked()
-        mocked_obj.config.update({"timeout": 200, "environment": "Sandbox"})
-
-        mocked_parse_args.return_value = mocked_obj
-        mocked_environment.return_value = mocked_obj
-
-        main()
-
-        mocked_configure.assert_called_with(
-            mocked_environment.Sandbox,
-            merchant_id="test",
-            public_key="test",
-            private_key="test",
-            timeout=200.0
-        )
+        self.assertEqual(str(e.exception), "Please provide a value greater than 0 for the request_timeout parameter in config")
 
     def test_timeout_no_value_in_config(self, mocked_parse_args, mocked_configure, mocked_discover, mocked_environment):
         """
-        Test when timeout is not provided in config
+        Test when request_timeout is not provided in config
         """
         mocked_obj = Mocked()
         mocked_obj.config.update({"environment": "Sandbox"})
@@ -118,7 +78,3 @@ class TestTimeout(unittest.TestCase):
             private_key="test",
             timeout=300.0
         )
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/tests/test_timeout.py
+++ b/tests/test_timeout.py
@@ -125,6 +125,42 @@ class TestTimeout(unittest.TestCase):
             timeout=200.0,
         )
 
+    def test_timeout_negative_string(self, mocked_parse_args, mocked_configure, mocked_discover, mocked_environment):
+        """
+        Test request_timeout as negative string falls back to default.
+        """
+        mocked_obj = Mocked()
+        mocked_obj.config.update({"request_timeout": "-5", "environment": "Sandbox"})
+        mocked_parse_args.return_value = mocked_obj
+        mocked_environment.return_value = mocked_obj
+
+        main()
+        mocked_configure.assert_called_with(
+            mocked_environment.Sandbox,
+            merchant_id="test",
+            public_key="test",
+            private_key="test",
+            timeout=300,
+        )
+
+    def test_timeout_negative_integer(self, mocked_parse_args, mocked_configure, mocked_discover, mocked_environment):
+        """
+        Test request_timeout as negative integer falls back to default.
+        """
+        mocked_obj = Mocked()
+        mocked_obj.config.update({"request_timeout": "-5", "environment": "Sandbox"})
+        mocked_parse_args.return_value = mocked_obj
+        mocked_environment.return_value = mocked_obj
+
+        main()
+        mocked_configure.assert_called_with(
+            mocked_environment.Sandbox,
+            merchant_id="test",
+            public_key="test",
+            private_key="test",
+            timeout=300,
+        )
+
     def test_timeout_valid_integer_type_value_in_config(
         self, mocked_parse_args, mocked_configure, mocked_discover, mocked_environment
     ):

--- a/tests/unittests/test_timeout.py
+++ b/tests/unittests/test_timeout.py
@@ -1,0 +1,124 @@
+import unittest
+from unittest import mock
+from tap_braintree import main
+
+
+class Mocked():
+    ''' Class to initialize required variables'''
+    def __init__(self):
+        self.config = {
+            "merchant_id": "test",
+            "public_key": "test",
+            "private_key": "test",
+            "start_date": "2017-01-17T20:32:05Z"
+        }
+        self.state = {}
+        self.catalog = {}
+        self.discover = True
+        self.environment = "Sandbox"
+
+
+@mock.patch("tap_braintree.braintree.Environment")
+@mock.patch("tap_braintree.do_discover")
+@mock.patch("tap_braintree.braintree.Configuration.configure")
+@mock.patch("tap_braintree.utils.parse_args")
+class TestTimeout(unittest.TestCase):
+    '''
+    Test class to validate fetched timeout value
+    '''
+
+    def test_timeout_invalid_value_zero_integer(self, mocked_parse_args, mocked_configure, mocked_discover, mocked_environment):
+        '''
+        Test zero integer timeout should raise ValueError
+        '''
+        mocked_obj = Mocked()
+        mocked_obj.config.update({"timeout": 0})
+        mocked_parse_args.return_value = mocked_obj
+        mocked_environment.return_value = mocked_obj
+
+        with self.assertRaises(ValueError) as e:
+            main()
+
+        self.assertEqual(str(e.exception), "Please provide a value greater than 0 for the timeout parameter in config")
+
+    def test_timeout_invalid_value_string_zero(self, mocked_parse_args, mocked_configure, mocked_discover, mocked_environment):
+        mocked_obj = Mocked()
+        mocked_obj.config.update({"timeout": "0"})
+        mocked_parse_args.return_value = mocked_obj
+        mocked_environment.return_value = mocked_obj
+        with self.assertRaises(ValueError) as e:
+            main()
+        self.assertEqual(str(e.exception), "Please provide a value greater than 0 for the timeout parameter in config")
+
+    def test_timeout_invalid_value_invalid_string(self, mocked_parse_args, mocked_configure, mocked_discover, mocked_environment):
+        mocked_obj = Mocked()
+        mocked_obj.config.update({"timeout": "abc"})
+        mocked_parse_args.return_value = mocked_obj
+        mocked_environment.return_value = mocked_obj
+        with self.assertRaises(ValueError) as e:
+            main()
+        self.assertEqual(str(e.exception), "Please provide a value greater than 0 for the timeout parameter in config")
+
+    def test_timeout_valid_string_type_value_in_config(self, mocked_parse_args, mocked_configure, mocked_discover, mocked_environment):
+        """
+        Test when timeout is provided as a string in config
+        """
+        mocked_obj = Mocked()
+        mocked_obj.config.update({"timeout": "200", "environment": "Sandbox"})
+
+        mocked_parse_args.return_value = mocked_obj
+        mocked_environment.return_value = mocked_obj
+
+        main()
+
+        mocked_configure.assert_called_with(
+            mocked_environment.Sandbox,
+            merchant_id="test",
+            public_key="test",
+            private_key="test",
+            timeout=200.0
+        )
+
+    def test_timeout_valid_integer_type_value_in_config(self, mocked_parse_args, mocked_configure, mocked_discover, mocked_environment):
+        """
+        Test when timeout is provided as an integer in config
+        """
+        mocked_obj = Mocked()
+        mocked_obj.config.update({"timeout": 200, "environment": "Sandbox"})
+
+        mocked_parse_args.return_value = mocked_obj
+        mocked_environment.return_value = mocked_obj
+
+        main()
+
+        mocked_configure.assert_called_with(
+            mocked_environment.Sandbox,
+            merchant_id="test",
+            public_key="test",
+            private_key="test",
+            timeout=200.0
+        )
+
+    def test_timeout_no_value_in_config(self, mocked_parse_args, mocked_configure, mocked_discover, mocked_environment):
+        """
+        Test when timeout is not provided in config
+        """
+        mocked_obj = Mocked()
+        mocked_obj.config.update({"environment": "Sandbox"})
+
+        mocked_parse_args.return_value = mocked_obj
+        mocked_environment.return_value = mocked_obj
+
+        main()
+
+        mocked_configure.assert_called_with(
+            mocked_environment.Sandbox,
+            merchant_id="test",
+            public_key="test",
+            private_key="test",
+            timeout=300.0
+        )
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
# Description of change
Handled extraction failures to handle timeout issues. 
 - search timeout
 - Unexpected HTTP_RESPONSE 502, ('Connection aborted.', RemoteDisconnected('Remote end closed connection without response'))
 - HTTPSConnectionPool(host='[api.braintreegateway.com](http://api.braintreegateway.com/)', port=443): Read timed out. (read timeout=60)

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch


