### PR TITLE
SAC-30419: Update state writing for tap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2.0.0
+  * Bump version to 2.0.0 changes in state writing format [#61](https://github.com/singer-io/tap-braintree/pull/61)
+
 ## 1.0.0
   * Add support of discovery mode [#55](https://github.com/singer-io/tap-braintree/pull/55)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## 2.0.0
-  * Bump version to 2.0.0 changes in state writing format [#61](https://github.com/singer-io/tap-braintree/pull/61)
+  * State standardization [#61](https://github.com/singer-io/tap-braintree/pull/61)
 
 ## 1.0.0
   * Add support of discovery mode [#55](https://github.com/singer-io/tap-braintree/pull/55)

--- a/README.md
+++ b/README.md
@@ -46,7 +46,15 @@ This tap:
     If you omit the file it will fetch all Braintree data.
 
     ```json
-    {"transactions": "2017-01-17T20:32:05Z"}
+    {
+        "bookmarks": {
+            "transactions": {
+                "latest_updated_at": "2024-01-01T00:00:00.000000Z",
+                "latest_disbursement_date": "2024-01-01T00:00:00.000000Z",
+                "updated_at": "2024-01-01T00:00:00.000000Z"
+            }
+        }
+    }
     ```
 
 5. Run the application

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup
 
 setup(name='tap-braintree',
-      version='1.0.0',
+      version='2.0.0',
       description='Singer.io tap for extracting data from the Braintree API',
       author='Stitch',
       url='http://singer.io',

--- a/tap_braintree/__init__.py
+++ b/tap_braintree/__init__.py
@@ -40,11 +40,16 @@ def load_schema(entity):
     return utils.load_json(get_abs_path("schemas/{}.json".format(entity)))
 
 
-def get_start(entity):
-    if entity not in STATE:
-        STATE[entity] = CONFIG["start_date"]
+def get_start(entity, replication_key: str):
 
-    return STATE[entity]
+    bookmark_data = singer.get_bookmark(
+        state=STATE,
+        tap_stream_id=entity,
+        key=replication_key,
+        default=CONFIG["start_date"]
+    )
+
+    return bookmark_data
 
 
 def to_utc(dt):
@@ -104,20 +109,37 @@ def get_transactions_data(start, end):
 
 
 def sync_transactions():
-    schema = load_schema("transactions")
+    global STATE
 
-    singer.write_schema("transactions", schema, ["id"],
-                        bookmark_properties=['created_at'])
+    tap_stream_id = "transactions"
+    valid_replication_key = "updated_at"
 
-    latest_updated_at = utils.strptime_to_utc(STATE.get('latest_updated_at', DEFAULT_TIMESTAMP))
+    schema = load_schema(tap_stream_id)
+
+    singer.write_schema(tap_stream_id, schema, ["id"],
+                        bookmark_properties=[valid_replication_key])
+
+    bk_latest_updated_at = singer.get_bookmark(
+        state=STATE,
+        tap_stream_id=tap_stream_id,
+        key="latest_updated_at",
+        default=DEFAULT_TIMESTAMP
+    )
+
+    bk_latest_disbursement_date = singer.get_bookmark(
+        state=STATE,
+        tap_stream_id=tap_stream_id,
+        key="latest_disbursement_date",
+        default=DEFAULT_TIMESTAMP
+    )
+
+    latest_updated_at = utils.strptime_to_utc(bk_latest_updated_at)
+    latest_disbursement_date = utils.strptime_to_utc(bk_latest_disbursement_date)
 
     run_maximum_updated_at = latest_updated_at
-
-    latest_disbursement_date = utils.strptime_to_utc(STATE.get('latest_disbursment_date', DEFAULT_TIMESTAMP))
-
     run_maximum_disbursement_date = latest_disbursement_date
 
-    latest_start_date = utils.strptime_to_utc(get_start("transactions"))
+    latest_start_date = utils.strptime_to_utc(get_start("transactions", replication_key=valid_replication_key))
 
     period_start = latest_start_date - TRAILING_DAYS
 
@@ -134,6 +156,7 @@ def sync_transactions():
     ))
 
     # increment through each day (20k results max from api)
+    end = period_end  # default so bookmark write is safe if loop never runs
     for start, end in daterange(period_start, period_end):
 
         end = min(end, period_end)
@@ -160,7 +183,7 @@ def sync_transactions():
             # set disbursement datetime to min if not found
 
             if row.disbursement_details is None:
-                disbursement_date = datetime.min
+                disbursement_date = to_utc(datetime.min)
 
             else:
                 if row.disbursement_details.disbursement_date is None:
@@ -212,16 +235,30 @@ def sync_transactions():
         run_maximum_disbursement_date
     ))
 
-    latest_updated_at = run_maximum_updated_at
+    latest_updated_at = utils.strftime(run_maximum_updated_at)
 
-    latest_disbursement_date = run_maximum_disbursement_date
+    latest_disbursement_date = utils.strftime(run_maximum_disbursement_date)
 
-    STATE['latest_updated_at'] = utils.strftime(latest_updated_at)
+    STATE = singer.write_bookmark(
+        state=STATE,
+        tap_stream_id=tap_stream_id,
+        key="latest_updated_at",
+        val=latest_updated_at
+    )
 
-    STATE['latest_disbursement_date'] = utils.strftime(
-        latest_disbursement_date)
+    STATE = singer.write_bookmark(
+        state=STATE,
+        tap_stream_id=tap_stream_id,
+        key="latest_disbursement_date",
+        val=latest_disbursement_date
+    )
 
-    utils.update_state(STATE, "transactions", utils.strftime(end))
+    STATE = singer.write_bookmark(
+        state=STATE,
+        tap_stream_id=tap_stream_id,
+        key=valid_replication_key,
+        val=utils.strftime(end)
+    )
 
     singer.write_state(STATE)
 

--- a/tap_braintree/__init__.py
+++ b/tap_braintree/__init__.py
@@ -41,6 +41,13 @@ def load_schema(entity):
 
 
 def get_start(entity, replication_key: str):
+    """ Function to extract bookmark details from state
+
+    Args:
+        entity (str): Stream id
+        replication_key (str): Valid replication key for that stream
+
+    """
 
     bookmark_data = singer.get_bookmark(
         state=STATE,
@@ -109,7 +116,7 @@ def get_transactions_data(start, end):
 
 
 def sync_transactions():
-    global STATE
+    global STATE  # STATE is updated in this function and needs to be global to be written at the end of the function
 
     tap_stream_id = "transactions"
     valid_replication_key = "updated_at"
@@ -119,6 +126,7 @@ def sync_transactions():
     singer.write_schema(tap_stream_id, schema, ["id"],
                         bookmark_properties=[valid_replication_key])
 
+    # Get the latest updated_at and disbursement_date from the bookmark, or use the default timestamp if not found
     bk_latest_updated_at = singer.get_bookmark(
         state=STATE,
         tap_stream_id=tap_stream_id,
@@ -239,6 +247,7 @@ def sync_transactions():
 
     latest_disbursement_date = utils.strftime(run_maximum_disbursement_date)
 
+    # State updation with latest updated_at and disbursement_date bookmarks
     STATE = singer.write_bookmark(
         state=STATE,
         tap_stream_id=tap_stream_id,

--- a/tests/unittests/test_state_standardisation.py
+++ b/tests/unittests/test_state_standardisation.py
@@ -1,0 +1,428 @@
+"""
+Unit tests for the state standardisation changes (fix/SAC-30419).
+
+Covers:
+    1. get_start() — returns bookmark value; falls back to CONFIG start_date
+    2. to_utc(datetime.min) — no TypeError on timezone-naive sentinel
+    3. Disbursement date comparison — UTC-aware datetime.min vs UTC-aware bookmark
+    4. sync_transactions() state shape — bookmarks structure per Singer spec
+    5. sync_transactions() — safe when daterange yields nothing (end = period_end)
+    6. bookmark_properties uses updated_at replication key
+"""
+
+import unittest
+from datetime import datetime
+from unittest import mock
+
+import pytz
+
+import tap_braintree
+from tap_braintree import get_start, sync_transactions, to_utc
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_row(
+    updated_at=None,
+    created_at=None,
+    disbursement_date=None,
+    disbursement_success=False,
+):
+    """Return a minimal mock Braintree transaction row."""
+    row = mock.MagicMock()
+    row.updated_at = updated_at or datetime(2024, 1, 15, 12, 0, 0)
+    row.created_at = created_at or datetime(2024, 1, 15, 12, 0, 0)
+
+    if disbursement_date is None:
+        row.disbursement_details = None
+    else:
+        row.disbursement_details = mock.MagicMock()
+        row.disbursement_details.disbursement_date = disbursement_date
+        row.disbursement_details.success = disbursement_success
+
+    return row
+
+
+def _make_search_result(rows, maximum_size=None):
+    """Return a mock braintree search result iterable."""
+    result = mock.MagicMock()
+    result.maximum_size = maximum_size if maximum_size is not None else len(rows)
+    result.__iter__ = mock.Mock(return_value=iter(rows))
+    return result
+
+
+# ---------------------------------------------------------------------------
+# 1. get_start()
+# ---------------------------------------------------------------------------
+
+class TestGetStart(unittest.TestCase):
+    """get_start() must return the bookmark value (or start_date fallback)."""
+
+    def setUp(self):
+        # Reset module-level globals before each test
+        tap_braintree.CONFIG.clear()
+        tap_braintree.STATE.clear()
+        tap_braintree.CONFIG["start_date"] = "2024-01-01T00:00:00Z"
+
+    def test_returns_start_date_when_no_bookmark(self):
+        """Falls back to CONFIG start_date when no bookmark exists."""
+        result = get_start("transactions", replication_key="updated_at")
+        self.assertEqual(result, "2024-01-01T00:00:00Z")
+
+    def test_returns_existing_bookmark(self):
+        """Returns the stored bookmark when present."""
+        tap_braintree.STATE = {
+            "bookmarks": {
+                "transactions": {"updated_at": "2024-06-01T00:00:00Z"}
+            }
+        }
+        result = get_start("transactions", replication_key="updated_at")
+        self.assertEqual(result, "2024-06-01T00:00:00Z")
+
+    def test_returns_value_not_none(self):
+        """Must never return None (old bug: missing return statement)."""
+        result = get_start("transactions", replication_key="updated_at")
+        self.assertIsNotNone(result)
+
+
+# ---------------------------------------------------------------------------
+# 2. to_utc with datetime.min (timezone-naive sentinel)
+# ---------------------------------------------------------------------------
+
+class TestToUtcWithDatetimeMin(unittest.TestCase):
+    """to_utc(datetime.min) must not raise and must be UTC-aware."""
+
+    def test_datetime_min_becomes_utc_aware(self):
+        """to_utc(datetime.min) returns a UTC-aware datetime."""
+        result = to_utc(datetime.min)
+        self.assertIsNotNone(result.tzinfo)
+        self.assertEqual(result.tzinfo, pytz.UTC)
+
+    def test_no_type_error_comparing_with_utc_bookmark(self):
+        """
+        Comparing to_utc(datetime.min) against a UTC-aware bookmark
+        must not raise TypeError (old bug: naive vs aware comparison).
+        """
+        utc_bookmark = datetime(2024, 1, 1, tzinfo=pytz.UTC)
+        sentinel = to_utc(datetime.min)
+        # Should not raise
+        try:
+            result = sentinel >= utc_bookmark
+            self.assertIsInstance(result, bool)
+        except TypeError:
+            self.fail("TypeError raised comparing to_utc(datetime.min) with UTC datetime")
+
+    def test_to_utc_regular_datetime(self):
+        """to_utc on a regular naive datetime attaches UTC timezone."""
+        dt = datetime(2024, 3, 17, 10, 30, 0)
+        result = to_utc(dt)
+        self.assertEqual(result.tzinfo, pytz.UTC)
+        self.assertEqual(result.year, 2024)
+        self.assertEqual(result.hour, 10)
+
+
+# ---------------------------------------------------------------------------
+# 3. Disbursement date: UTC-aware sentinel used in comparison
+# ---------------------------------------------------------------------------
+
+class TestDisbursementDateSentinel(unittest.TestCase):
+    """
+    When disbursement_details is None the disbursement_date sentinel
+    must be UTC-aware so it can be compared with the UTC-aware bookmark.
+    """
+
+    @mock.patch("tap_braintree.singer.write_state")
+    @mock.patch("tap_braintree.singer.write_record")
+    @mock.patch("tap_braintree.singer.write_schema")
+    @mock.patch("tap_braintree.load_schema", return_value={})
+    @mock.patch("tap_braintree.transform_row", return_value={"id": "tx1"})
+    @mock.patch("tap_braintree.get_transactions_data")
+    def test_no_type_error_null_disbursement(
+        self,
+        mock_get_data,
+        mock_transform,
+        mock_load_schema,
+        mock_write_schema,
+        mock_write_record,
+        mock_write_state,
+    ):
+        """
+        A row with disbursement_details=None must not raise TypeError during
+        the disbursement_date >= latest_disbursement_date comparison.
+        """
+        tap_braintree.CONFIG.clear()
+        tap_braintree.STATE.clear()
+        tap_braintree.CONFIG["start_date"] = "2024-01-14T00:00:00Z"
+
+        row = _make_row(
+            updated_at=datetime(2024, 1, 15, 12, 0, 0),
+            disbursement_date=None,  # triggers disbursement_date = to_utc(datetime.min)
+        )
+        mock_get_data.return_value = _make_search_result([row])
+
+        # Should complete without TypeError
+        try:
+            with mock.patch("tap_braintree.utils.now") as mock_now:
+                mock_now.return_value = datetime(2024, 1, 15, tzinfo=pytz.UTC)
+                sync_transactions()
+        except TypeError as e:
+            self.fail(f"TypeError raised: {e}")
+
+
+# ---------------------------------------------------------------------------
+# 4. Singer state shape — bookmarks structure
+# ---------------------------------------------------------------------------
+
+class TestStateShape(unittest.TestCase):
+    """
+    After sync_transactions(), singer.write_state() must be called with a
+    state dict that has the canonical Singer bookmarks structure:
+      {"bookmarks": {"transactions": {...}}}
+    """
+
+    @mock.patch("tap_braintree.singer.write_state")
+    @mock.patch("tap_braintree.singer.write_record")
+    @mock.patch("tap_braintree.singer.write_schema")
+    @mock.patch("tap_braintree.load_schema", return_value={})
+    @mock.patch("tap_braintree.transform_row", return_value={"id": "tx1"})
+    @mock.patch("tap_braintree.get_transactions_data")
+    def test_state_has_bookmarks_key(
+        self,
+        mock_get_data,
+        mock_transform,
+        mock_load_schema,
+        mock_write_schema,
+        mock_write_record,
+        mock_write_state,
+    ):
+        tap_braintree.CONFIG.clear()
+        tap_braintree.STATE.clear()
+        tap_braintree.CONFIG["start_date"] = "2024-01-14T00:00:00Z"
+
+        row = _make_row(updated_at=datetime(2024, 1, 15, 12, 0, 0))
+        mock_get_data.return_value = _make_search_result([row])
+
+        with mock.patch("tap_braintree.utils.now") as mock_now:
+            mock_now.return_value = datetime(2024, 1, 15, tzinfo=pytz.UTC)
+            sync_transactions()
+
+        written_state = mock_write_state.call_args[0][0]
+        self.assertIn("bookmarks", written_state)
+        self.assertIn("transactions", written_state["bookmarks"])
+
+    @mock.patch("tap_braintree.singer.write_state")
+    @mock.patch("tap_braintree.singer.write_record")
+    @mock.patch("tap_braintree.singer.write_schema")
+    @mock.patch("tap_braintree.load_schema", return_value={})
+    @mock.patch("tap_braintree.transform_row", return_value={"id": "tx1"})
+    @mock.patch("tap_braintree.get_transactions_data")
+    def test_state_bookmarks_contains_required_keys(
+        self,
+        mock_get_data,
+        mock_transform,
+        mock_load_schema,
+        mock_write_schema,
+        mock_write_record,
+        mock_write_state,
+    ):
+        """
+        The transactions bookmark must contain latest_updated_at,
+        latest_disbursement_date and updated_at.
+        """
+        tap_braintree.CONFIG.clear()
+        tap_braintree.STATE.clear()
+        tap_braintree.CONFIG["start_date"] = "2024-01-14T00:00:00Z"
+
+        row = _make_row(updated_at=datetime(2024, 1, 15, 12, 0, 0))
+        mock_get_data.return_value = _make_search_result([row])
+
+        with mock.patch("tap_braintree.utils.now") as mock_now:
+            mock_now.return_value = datetime(2024, 1, 15, tzinfo=pytz.UTC)
+            sync_transactions()
+
+        bk = mock_write_state.call_args[0][0]["bookmarks"]["transactions"]
+        self.assertIn("latest_updated_at", bk)
+        self.assertIn("latest_disbursement_date", bk)
+        self.assertIn("updated_at", bk)
+
+    @mock.patch("tap_braintree.singer.write_state")
+    @mock.patch("tap_braintree.singer.write_record")
+    @mock.patch("tap_braintree.singer.write_schema")
+    @mock.patch("tap_braintree.load_schema", return_value={})
+    @mock.patch("tap_braintree.transform_row", return_value={"id": "tx1"})
+    @mock.patch("tap_braintree.get_transactions_data")
+    def test_state_bookmark_values_are_strings(
+        self,
+        mock_get_data,
+        mock_transform,
+        mock_load_schema,
+        mock_write_schema,
+        mock_write_record,
+        mock_write_state,
+    ):
+        """Bookmark values written to state must be ISO-format strings."""
+        tap_braintree.CONFIG.clear()
+        tap_braintree.STATE.clear()
+        tap_braintree.CONFIG["start_date"] = "2024-01-14T00:00:00Z"
+
+        row = _make_row(updated_at=datetime(2024, 1, 15, 12, 0, 0))
+        mock_get_data.return_value = _make_search_result([row])
+
+        with mock.patch("tap_braintree.utils.now") as mock_now:
+            mock_now.return_value = datetime(2024, 1, 15, tzinfo=pytz.UTC)
+            sync_transactions()
+
+        expected_state = {
+            "bookmarks": {
+                "transactions": {
+                    "latest_updated_at": "2024-01-15T12:00:00.000000Z",
+                    "latest_disbursement_date": "1970-01-01T00:00:00.000000Z",
+                    "updated_at": "2024-01-15T00:00:00.000000Z"
+                }
+            }
+        }
+
+        self.assertEqual(mock_write_state.call_args[0][0], expected_state)
+
+        bk = mock_write_state.call_args[0][0]["bookmarks"]["transactions"]
+        self.assertIsInstance(bk["latest_updated_at"], str)
+        self.assertIsInstance(bk["latest_disbursement_date"], str)
+        self.assertIsInstance(bk["updated_at"], str)
+
+
+# ---------------------------------------------------------------------------
+# 5. Empty daterange — end defaults to period_end, no NameError
+# ---------------------------------------------------------------------------
+
+class TestEmptyDaterange(unittest.TestCase):
+    """
+    When period_start == period_end (empty daterange), sync_transactions()
+    must not raise NameError for undefined `end` variable.
+    """
+
+    @mock.patch("tap_braintree.singer.write_state")
+    @mock.patch("tap_braintree.singer.write_schema")
+    @mock.patch("tap_braintree.load_schema", return_value={})
+    @mock.patch("tap_braintree.get_transactions_data")
+    def test_no_name_error_when_loop_never_runs(
+        self,
+        mock_get_data,
+        mock_load_schema,
+        mock_write_schema,
+        mock_write_state,
+    ):
+        """
+        An end_date equal to start_date produces no loop iterations.
+        Must not raise NameError and must still call write_state.
+        """
+        tap_braintree.CONFIG.clear()
+        tap_braintree.STATE.clear()
+        # Set start_date far in the future so period_end < period_start
+        tap_braintree.CONFIG["start_date"] = "2030-01-01T00:00:00Z"
+        tap_braintree.CONFIG["end_date"] = "2030-01-01T00:00:00Z"
+
+        try:
+            sync_transactions()
+        except NameError as e:
+            self.fail(f"NameError raised (end variable undefined): {e}")
+
+        mock_write_state.assert_called_once()
+
+    @mock.patch("tap_braintree.singer.write_state")
+    @mock.patch("tap_braintree.singer.write_schema")
+    @mock.patch("tap_braintree.load_schema", return_value={})
+    @mock.patch("tap_braintree.get_transactions_data")
+    def test_updated_at_bookmark_equals_period_end_when_loop_empty(
+        self,
+        mock_get_data,
+        mock_load_schema,
+        mock_write_schema,
+        mock_write_state,
+    ):
+        """
+        When the loop never runs, the updated_at bookmark written to state
+        must equal period_end (the safe default for `end`).
+        """
+        tap_braintree.CONFIG.clear()
+        tap_braintree.STATE.clear()
+        tap_braintree.CONFIG["start_date"] = "2030-01-01T00:00:00Z"
+        tap_braintree.CONFIG["end_date"] = "2030-01-01T00:00:00Z"
+
+        sync_transactions()
+
+        written_state = mock_write_state.call_args[0][0]
+        bk = written_state["bookmarks"]["transactions"]
+        # updated_at bookmark must be a string (not missing/None)
+        self.assertIsNotNone(bk.get("updated_at"))
+        self.assertIsInstance(bk["updated_at"], str)
+
+
+# ---------------------------------------------------------------------------
+# 6. write_schema called with bookmark_properties=['updated_at']
+# ---------------------------------------------------------------------------
+
+class TestWriteSchemaBookmarkProperties(unittest.TestCase):
+    """
+    singer.write_schema() must be called with bookmark_properties=['updated_at'],
+    matching the actual replication key — not 'created_at'.
+    """
+
+    @mock.patch("tap_braintree.singer.write_state")
+    @mock.patch("tap_braintree.singer.write_record")
+    @mock.patch("tap_braintree.singer.write_schema")
+    @mock.patch("tap_braintree.load_schema", return_value={})
+    @mock.patch("tap_braintree.transform_row", return_value={"id": "tx1"})
+    @mock.patch("tap_braintree.get_transactions_data")
+    def test_bookmark_properties_is_updated_at(
+        self,
+        mock_get_data,
+        mock_transform,
+        mock_load_schema,
+        mock_write_schema,
+        mock_write_record,
+        mock_write_state,
+    ):
+        tap_braintree.CONFIG.clear()
+        tap_braintree.STATE.clear()
+        tap_braintree.CONFIG["start_date"] = "2024-01-14T00:00:00Z"
+
+        row = _make_row(updated_at=datetime(2024, 1, 15, 12, 0, 0))
+        mock_get_data.return_value = _make_search_result([row])
+
+        with mock.patch("tap_braintree.utils.now") as mock_now:
+            mock_now.return_value = datetime(2024, 1, 15, tzinfo=pytz.UTC)
+            sync_transactions()
+
+        _, kwargs = mock_write_schema.call_args
+        self.assertEqual(kwargs.get("bookmark_properties"), ["updated_at"])
+
+    @mock.patch("tap_braintree.singer.write_state")
+    @mock.patch("tap_braintree.singer.write_record")
+    @mock.patch("tap_braintree.singer.write_schema")
+    @mock.patch("tap_braintree.load_schema", return_value={})
+    @mock.patch("tap_braintree.transform_row", return_value={"id": "tx1"})
+    @mock.patch("tap_braintree.get_transactions_data")
+    def test_bookmark_properties_not_created_at(
+        self,
+        mock_get_data,
+        mock_transform,
+        mock_load_schema,
+        mock_write_schema,
+        mock_write_record,
+        mock_write_state,
+    ):
+        tap_braintree.CONFIG.clear()
+        tap_braintree.STATE.clear()
+        tap_braintree.CONFIG["start_date"] = "2024-01-14T00:00:00Z"
+
+        row = _make_row(updated_at=datetime(2024, 1, 15, 12, 0, 0))
+        mock_get_data.return_value = _make_search_result([row])
+
+        with mock.patch("tap_braintree.utils.now") as mock_now:
+            mock_now.return_value = datetime(2024, 1, 15, tzinfo=pytz.UTC)
+            sync_transactions()
+
+        _, kwargs = mock_write_schema.call_args
+        self.assertNotIn("created_at", kwargs.get("bookmark_properties", []))


### PR DESCRIPTION
# Description of change
- Update the state writing for the tap to follow singer standard
- The tap is writing state using a flat, non-standard structure. Below is the current format:
```
{
  "transactions": "2025-06-14T00:00:00.000000Z",
  "latest_updated_at": "2025-06-13T09:15:48.000000Z",
  "latest_disbursement_date": "2025-06-14T00:00:00.000000Z"
}
```

- Updated state reads and writes to use singer.get_bookmark() / singer.write_bookmark() / singer.write_state(), producing the canonical Singer state shape:
```
{"bookmarks": {"transactions": {...}}}
```

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch

#### AI generated code
https://internal.qlik.dev/general/ways-of-working/code-reviews/#guidelines-for-ai-generated-code
- [ ] this PR has been written with the help of GitHub Copilot or another generative AI tool
